### PR TITLE
Update Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
 
+services:
+  - redis
+
 python:
   - "2.6"
   - "2.7"
 
 install:
-  - pip install . --quiet --use-mirrors
+  - pip install . --quiet --use-mirrors --no-use-wheel
   - pip install nose --quiet --use-mirrors
 
 script: nosetests

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
 Flask-RQ
 ========
 
-.. image:: https://secure.travis-ci.org/mattupstate/flask-principal.png?branch=develop
+.. image:: https://travis-ci.org/mattupstate/flask-rq.svg?branch=master
+    :target: https://travis-ci.org/mattupstate/flask-rq
 
 RQ (Redis Queue) integration for Flask applications
 


### PR DESCRIPTION
- Currently all PR builds [are failing](https://travis-ci.org/mattupstate/flask-rq/pull_requests) because `rq` has started supporting wheel packages which don't include the deps for python 2.6. This should fix that. Also created an issue there (nvie/rq#540)
- Added redis requirement
- Updated the image